### PR TITLE
[DPE-7429] Remove symlinks preventing publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,7 @@ concurrency:
 on:
   push:
     branches:
+      - main
       - '*/edge'
     paths:
       - snap/**

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -147,6 +147,10 @@ parts:
       - iproute2
       - numactl
       - libev4t64
+    override-prime: |-
+      snapcraftctl prime
+      rm -vf usr/lib/jvm/java-11-openjdk-amd64/lib/security/cacerts
+      rm -vf usr/lib/jvm/java-11-openjdk-amd64/lib/security/blacklisted.certs
 
   cqlsh:
     plugin: python


### PR DESCRIPTION
I tried to publish the version on main, but I got the following error:

```
Issues while processing snap:
- package contains external symlinks: usr/lib/jvm/java-11-openjdk-amd64/lib/security/blacklisted.certs -> /etc/java-11-openjdk/security/blacklisted.certs
Full execution log: '/home/deusebio/.local/state/snapcraft/log/snapcraft-20250611-170329.126147.log'
```

I have fixed this by applying a patch that we also had in ZooKeeper, see [here](https://github.com/canonical/charmed-zookeeper-snap/blob/3/edge/snap/snapcraft.yaml#L67).