### PR TITLE
Change mgmt-server libs path to current

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: connect-interfaces enable-mgmtapi
+.PHONY: connect-interfaces enable-mgmtapi sysctl-tuning
 
 connect-interfaces:
 	sudo snap connect charmed-cassandra:process-control
@@ -12,6 +12,6 @@ sysctl-tuning:
 
 enable-mgmtapi:
 	@echo "\nEnabling Management API..."
-	@rev=$$(curl --silent --unix-socket /run/snapd.socket http://localhost/v2/snaps/charmed-cassandra | jq -r '.result.revision'); \
-	echo "JVM_OPTS=\"\$$JVM_OPTS -javaagent:/snap/charmed-cassandra/$${rev}/opt/mgmt-api/libs/datastax-mgmtapi-agent.jar\"" \
+
+	echo "JVM_OPTS=\"\$$JVM_OPTS -javaagent:/snap/charmed-cassandra/current/opt/mgmt-api/libs/datastax-mgmtapi-agent.jar\"" \
 	| sudo tee -a /var/snap/charmed-cassandra/current/etc/cassandra/cassandra-env.sh

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,7 +80,7 @@ apps:
     environment:
       MGMT_API_LOG_DIR: ${CASSANDRA_LOG_DIR}
       MGMT_API_DISABLE_MCAC: "true"
-      MGMT_API_DIR: ${SNAP}/opt/mgmt-api
+      MGMT_API_DIR: /snap/charmed-cassandra/current/opt/mgmt-api
       MGMT_API_PORT: 8080
 
   cassandra-bin:


### PR DESCRIPTION
## Summary

Update the `cassandra-env.sh` configuration to use the `current` path for `mgmt-server` libraries instead of a revision-specific path.

## Details

Previously, `start-wrapper.sh` checked if the `mgmt-server` patch was applied correctly to `cassandra-env.sh` by looking for a revision-based path.  
This caused issues during the development of the `cassandra-charm`, where retrieving the Snap revision and patching the config manually was inconvenient.

Switching to the `current` path simplifies this process by removing the need to track specific Snap revisions when referencing `mgmt-server` libraries.