### PR TITLE
Remove setpriv from python-wrapper.sh

### DIFF
--- a/snap/local/opt/cqlsh/bin/python-wrapper.sh
+++ b/snap/local/opt/cqlsh/bin/python-wrapper.sh
@@ -3,9 +3,4 @@ set -e
 
 export PYTHONPATH="${SNAP}/lib/python3.12/site-packages"
 
-exec "${SNAP}/usr/bin/setpriv" \
-    --clear-groups \
-    --reuid _daemon_ \
-    --regid _daemon_ \
-    -- \
-    "${SNAP}/bin/python3" "${SNAP}/bin/"${bin} "$@"
+exec "${SNAP}/bin/python3" "${SNAP}/bin/${bin}" "$@"


### PR DESCRIPTION
### Problem

Due to the use of `setpriv` in `python-wrapper.sh`, `cqlsh` was executed as the `_daemon_` user.  
This resulted in the following error when attempting to connect to cassandra:
```
Warning: Cannot create directory at `/root/snap/charmed-cassandra/x1/.cassandra`. Command history will not be saved. Please check what was the environment property CQL_HISTORY set to.

Traceback (most recent call last):
  File "/snap/charmed-cassandra/x1/bin/cqlsh", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/snap/charmed-cassandra/x1/lib/python3.12/site-packages/cqlshlib/__main__.py", line 7, in main
    cqlsh_main(sys.argv[1:], "")
  File "/snap/charmed-cassandra/x1/lib/python3.12/site-packages/cqlshlib/cqlshmain.py", line 2267, in main
    (options, hostname, port) = read_options(cmdline)
                                ^^^^^^^^^^^^^^^^^^^^^
  File "/snap/charmed-cassandra/x1/lib/python3.12/site-packages/cqlshlib/cqlshmain.py", line 2124, in read_options
    if not is_file_secure(options.credentials):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/snap/charmed-cassandra/x1/lib/python3.12/site-packages/cqlshlib/util.py", line 119, in is_file_secure
    st = os.stat(filename)
         ^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/root/snap/charmed-cassandra/x1/.cassandra/credentials'
```

---

### Solution

After removing `setpriv`, `cqlsh` now runs as the invoking user and is able to:
- create `.cassandra/` directory in `$HOME`, and
- function without permission issues.

This resolves the error and allows `cqlsh` to work correctly in a snap environment.


@marcoppenheimer

