### PR TITLE
Fix strict mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Install snap file
         run: |
           version="$(yq .version < snap/snapcraft.yaml)"
-          sudo snap install "charmed-cassandra_${version}_amd64.snap" --dangerous --devmode
+          sudo snap install "charmed-cassandra_${version}_amd64.snap" --dangerous
 
       - name: Connect required interfaces
         run: |
@@ -69,7 +69,7 @@ jobs:
       - name: Upgrade snap
         run: |
           version="$(yq .version < snap/snapcraft.yaml)"
-          sudo snap install "charmed-cassandra_${version}_amd64.snap" --dangerous --devmode
+          sudo snap install "charmed-cassandra_${version}_amd64.snap" --dangerous
 
           if [ -d /var/snap/charmed-cassandra/x2 ]; then
               echo "Snap upgraded."

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 connect-interfaces:
 	sudo snap connect charmed-cassandra:process-control
 	sudo snap connect charmed-cassandra:system-observe
+	sudo snap connect charmed-cassandra:mount-observe
+	sudo snap connect charmed-cassandra:hardware-observe
 
 # See: https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/install/installRecommendSettings.html#Setuserresourcelimits
 sysctl-tuning:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,7 +49,7 @@ environment:
 
   CASSANDRA_LOG_DIR: ${SNAP_COMMON}/var/log/cassandra
 
-  PATH: ${SNAP}/opt/cassandra/bin:${JAVA_HOME}/bin:$PATH
+  PATH: ${SNAP}/opt/cassandra/bin:${JAVA_HOME}/bin:${SNAP}/usr/bin:$PATH
 
 apps:
   daemon:
@@ -64,6 +64,7 @@ apps:
       - hardware-observe
       - process-control
       - system-observe
+      - mount-observe # To be able to get disk space
 
   mgmt-server:
     daemon: simple
@@ -77,6 +78,7 @@ apps:
       - hardware-observe
       - process-control
       - system-observe
+      - mount-observe
     environment:
       MGMT_API_LOG_DIR: ${CASSANDRA_LOG_DIR}
       MGMT_API_DISABLE_MCAC: "true"
@@ -96,6 +98,9 @@ apps:
     plugs:
       - network
       - network-bind
+      - process-control # To be able to kill cassandra process
+      - system-observe
+      - mount-observe # To be able to use stopdaemon
     environment:
       bin_script: nodetool
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,7 +64,7 @@ apps:
       - hardware-observe
       - process-control
       - system-observe
-      - mount-observe # To be able to get disk space
+      - mount-observe
 
   mgmt-server:
     daemon: simple
@@ -98,9 +98,9 @@ apps:
     plugs:
       - network
       - network-bind
-      - process-control # To be able to kill cassandra process
+      - process-control
       - system-observe
-      - mount-observe # To be able to use stopdaemon
+      - mount-observe
     environment:
       bin_script: nodetool
 


### PR DESCRIPTION
# Cassandra Snap: Environment and Permissions Fix in strict mode

## Summary

This PR improves the Cassandra Snap runtime environment by adjusting the environment variables and adding required Snap interfaces to enable full functionality of both Cassandra and the `nodetool` utility.

## Changes

- **Environment Fix for `free` Utility**  
  Updated the Snap `PATH` to include `${SNAP}/usr/bin`, allowing `cassandra-env.sh` to use the `free` command for memory detection.  
  **New PATH:**  
  ```bash
  ${SNAP}/opt/cassandra/bin:${JAVA_HOME}/bin:${SNAP}/usr/bin:$PATH
  ```

- **Added `mount-observe` Plug for Cassandra**  
  The Cassandra daemon requires access to disk usage information via `FileStore.getUsableSpace()` in order to validate data directories such as `commitlog`. Without the `mount-observe` plug, AppArmor prevents this, leading to startup failures. This plug resolves the issue.

- **Extended `nodetool` App Permissions**  
  - Added `mount-observe` so that `nodetool` can successfully initialize and connect over JMX.
  - Added `process-control` to allow `nodetool` to terminate the Cassandra process cleanly.
  
  @marcoppenheimer