### PR TITLE
Remove unused folder

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -26,7 +26,6 @@ function create_file_structure () {
     done
 
     copy_files_between_folder "${SNAP}/etc/cassandra/" "${CASSANDRA_CONF}/"
-    copy_files_between_folder "${SNAP}/opt/cassandra/" "${CASSANDRA_HOME}/"
 }
 
 function set_base_config_props () {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,7 +43,7 @@ hooks:
 environment:
   JAVA_HOME: ${SNAP}/usr/lib/jvm/java-11-openjdk-amd64
 
-  CASSANDRA_HOME: ${SNAP_DATA}/opt/cassandra
+  CASSANDRA_HOME: ${SNAP}/opt/cassandra
 
   CASSANDRA_CONF: ${SNAP_DATA}/etc/cassandra
 


### PR DESCRIPTION
Remove unused `/var/snap/charmed-cassandra/current/opt/cassandra/` folder with the content that is expected on the snap squashfs system.

@marcoppenheimer