### PR TITLE
[DPE-7599] Use pypl to pull cqlsh

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -169,8 +169,9 @@ parts:
 
   cqlsh:
     plugin: python
-    source: https://github.com/jeffwidman/cqlsh.git
-    source-tag: 6.2.0
+    source: .
+    python-packages:
+      - cqlsh
 
   mgmt-api:
     plugin: nil


### PR DESCRIPTION
### Fix: Update `cqlsh` to Latest Version

**Related issue/discussion:** [Original comment](https://github.com/canonical/charmed-cassandra-snap/pull/8#discussion_r2155490202)

With this fix, the newest version of **cqlsh** will be used. New version will be pulled from PyPl.
The snap ships with `cqlsh 6.2.1`, which is compatible with **Cassandra 5.0.5**, according to the official [repo](https://github.com/jeffwidman/cqlsh):

> **6.2.1 (August 6, 2025)**
> This packages `cqlsh 6.2.0` from [Cassandra 5.0.5](https://github.com/apache/cassandra/blob/cassandra-5.0.5/pylib/cqlshlib)

---

#### Current Issue

Despite this, the following warning is still shown:

```
$ sudo snap run charmed-cassandra.cqlsh --version
cqlsh 6.2.1

$ sudo snap run charmed-cassandra.cqlsh -e exit
WARNING: cqlsh was built against 5.0.0, but this server is 5.0.5.  All features may not work!
```

---

#### Impact of This PR

* Ensures the **latest `cqlsh` version** is pulled in.
* This should remove the version mismatch warning once an updated release becomes available.