### PR TITLE
Disable auto-restart for Cassandra & Management API services

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,8 +56,7 @@ apps:
     daemon: simple
     command: opt/cassandra/bin/start-wrapper.sh
     install-mode: disable
-    restart-condition: always
-    restart-delay: 20s
+    restart-condition: never
     plugs:
       - network
       - network-bind
@@ -70,8 +69,7 @@ apps:
     daemon: simple
     command: opt/cassandra/bin/start-wrapper-mgmt.sh
     install-mode: disable
-    restart-condition: always
-    restart-delay: 20s
+    restart-condition: never
     plugs:
       - network
       - network-bind
@@ -259,7 +257,6 @@ parts:
 
       cp jmx_prometheus_javaagent-1.0.1.jar \
       ${CRAFT_PART_INSTALL}/opt/cassandra/lib/jmx_prometheus_javaagent-1.0.1.jar
-
 
   wrapper:
     plugin: dump


### PR DESCRIPTION
Without auto-restart it is easier to observe faulty service from the charm perspective, especially in the bootstrap / health check cases.
Cassandra bootstrapping example: when Cassandra encounters an error, it shutdowns with exception in the service logs. And it's difficult for charm to observe this, as service restarts constantly and in 99% cases it seems just like very long yet ordinary starting process.
Health check example: if service dies, it will be restarted without charm acknowledge, so we'll miss this important event and will not notify user about this through error log (in update-status, for example).

Re @marcoppenheimer:
> Definitely turn off auto-restart IMO. Charm should check for service on update-status and restart itself if needed.