### PR TITLE
[MISK] Add nosqlbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,32 @@ To enable **metrics** collection via the Prometheus JMX Exporter:
 
 You should see a list of JVM and Cassandra metrics in Prometheus format.
 
+## Benchmark
+
+To evaluate Cassandra performance, you can use **NoSQLBench**, which is included in the Charmed Cassandra snap.
+
+1. Run a baseline benchmark using the provided NoSQLBench activity file:
+
+   ```bash
+   sudo charmed-cassandra.nosqlbench /activities/baselines/cql-keyvalue.yaml \
+       host=127.0.0.1 \
+       port=9042 \
+       localdc=datacenter1 \
+       keyspace=nb5_test \
+       driver=cql -v
+   ```
+
+   * `host`: Cassandra node address
+   * `port`: Cassandra CQL port (`9042` by default)
+   * `localdc`: Local datacenter name (`datacenter1` by default)
+   * `keyspace`: Keyspace to run the benchmark on
+   * `driver`: Protocol driver
+   * `-v`: Verbose output
+
+2. You should see detailed summary about read/write operations, latency, and throughput in stdout.
+
+3. After benchmarking, you can analyze results to tune Cassandra performance (e.g., heap size, compaction strategy, replication factor).
+
 ## License
 
 The Apache Cassandra Snap is free software, distributed under the Apache Software License, version 2.0. See [LICENSE](https://github.com/canonical/charmed-cassandra-snap/LICENSE) for more information.

--- a/snap/local/opt/nosqlbench/bin/java-wrapper.sh
+++ b/snap/local/opt/nosqlbench/bin/java-wrapper.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+"${SNAP}"/usr/bin/setpriv \
+    --clear-groups \
+    --reuid _daemon_ \
+    --regid _daemon_ -- \
+    ${SNAP}/usr/lib/jvm/${java}/bin/java \
+    -Duser.home="${SNAP_COMMON}/home/_daemon_" \
+    -jar ${SNAP}/opt/nosqlbench/bin/${jar} \
+    "${@}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -128,7 +128,7 @@ apps:
     environment:
       jar: nb5.jar
       java: java-17-openjdk-amd64
-    
+
   jmxtool:
     command: opt/cassandra/bin/tool-wrapper.sh
     plugs:
@@ -243,7 +243,7 @@ parts:
       for res in "${resources[@]}"; do
           rm -rf "${CRAFT_PART_INSTALL}/${res}"
       done
-      
+
   jmx-exporter:
     plugin: nil
     after: [cassandra]
@@ -259,14 +259,14 @@ parts:
 
       cp jmx_prometheus_javaagent-1.0.1.jar \
       ${CRAFT_PART_INSTALL}/opt/cassandra/lib/jmx_prometheus_javaagent-1.0.1.jar
-      
+
   wrapper:
     plugin: dump
     source: snap/local
 
   nosqlbench:
     plugin: nil
-    after: [cassandra]    
+    after: [cassandra]
     source: >-
       https://github.com/nosqlbench/nosqlbench/releases/download/5.17.3-release/nb5.jar
     source-checksum: >-
@@ -275,4 +275,3 @@ parts:
     override-build: |
       mkdir -p ${CRAFT_PART_INSTALL}/opt/nosqlbench/bin
       cp nb5.jar ${CRAFT_PART_INSTALL}/opt/nosqlbench/bin/nb5.jar
-

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -120,14 +120,15 @@ apps:
     environment:
       bin: cqlsh
 
-  stress:
-    command: opt/cassandra/bin/tool-wrapper.sh
+  nosqlbench:
+    command: opt/nosqlbench/bin/java-wrapper.sh
     plugs:
       - network
       - network-bind
     environment:
-      bin_script: cassandra-stress
-
+      jar: nb5.jar
+      java: java-17-openjdk-amd64
+    
   jmxtool:
     command: opt/cassandra/bin/tool-wrapper.sh
     plugs:
@@ -149,6 +150,7 @@ parts:
     stage-packages:
       - util-linux
       - openjdk-11-jre-headless
+      - openjdk-17-jdk-headless
       - python3
       - curl
       - net-tools
@@ -241,7 +243,7 @@ parts:
       for res in "${resources[@]}"; do
           rm -rf "${CRAFT_PART_INSTALL}/${res}"
       done
-
+      
   jmx-exporter:
     plugin: nil
     after: [cassandra]
@@ -257,7 +259,20 @@ parts:
 
       cp jmx_prometheus_javaagent-1.0.1.jar \
       ${CRAFT_PART_INSTALL}/opt/cassandra/lib/jmx_prometheus_javaagent-1.0.1.jar
-
+      
   wrapper:
     plugin: dump
     source: snap/local
+
+  nosqlbench:
+    plugin: nil
+    after: [cassandra]    
+    source: >-
+      https://github.com/nosqlbench/nosqlbench/releases/download/5.17.3-release/nb5.jar
+    source-checksum: >-
+      sha256/54aed15049f0092a085c79beefa0f6567316af411d4d628e504888e0013f436a
+    source-type: file
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/opt/nosqlbench/bin
+      cp nb5.jar ${CRAFT_PART_INSTALL}/opt/nosqlbench/bin/nb5.jar
+

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2,10 +2,6 @@ import subprocess
 import yaml
 import pytest
 
-NUM_OPS = 100
-THREADS = 2
-CL = "ONE"
-
 def run_command(cmd):
     result = subprocess.run(cmd, shell=False, text=True, capture_output=True)
     if result.returncode != 0:
@@ -68,44 +64,40 @@ def test_nodetool_status():
         
 
 @pytest.mark.run(after="test_nodetool_status")
-def test_write_stress():
+def test_nosqlbench_basic_check():
     if not is_snap_installed():
         pytest.fail("[FAILED] snap command not found")
 
-    if not cassandra_stress_available():
-        pytest.fail("[FAILED] cassandra-stress is not installed or not available via snap")
+    print("▶ Starting NoSQLBench basic_check...")
 
-    print("▶ Starting WRITE test...")
+    cmd = [
+        "sudo",
+        "snap",
+        "run",
+        "charmed-cassandra.nosqlbench",
+        "/activities/baselines/cql-keyvalue.yaml",
+        "basic_check",
+        "host=127.0.0.1",
+        "port=9042",
+        "localdc=datacenter1",
+        "keyspace=nb5_test",
+        "driver=cql",
+        "-v",
+    ]
+
+    output = ""
+
     try:
-        run_command([
-            "sudo", "snap", "run", "charmed-cassandra.stress", "write",
-            f"n={NUM_OPS}",
-            f"cl={CL}",
-            "-rate",
-            f"threads={THREADS}"
-        ])
+        output = run_command(cmd)
     except subprocess.CalledProcessError:
-        pytest.fail("[FAILED] WRITE test failed")
-    print("[SUCCESS] WRITE test completed")
+        pytest.fail("[FAILED] NoSQLBench basic_check failed")
 
-@pytest.mark.run(after="test_nodetool_status")
-def test_read_stress():
-    if not is_snap_installed():
-        pytest.fail("[FAILED] snap command not found")
+    print(f"NoSQLBench result: \n{output}")
 
-    if not cassandra_stress_available():
-        pytest.fail("[FAILED] cassandra-stress is not installed or not available via snap")
+    if "Scenario completed successfully" not in output:
+        pytest.fail(
+            "[FAILED] NoSQLBench did not complete successfully "
+            "(missing 'Scenario completed successfully')"
+        )
 
-    
-    print("▶ Starting READ test...")
-    try:
-        run_command([
-            "sudo", "snap", "run", "charmed-cassandra.stress", "read",
-            f"n={NUM_OPS}",
-            f"cl={CL}",
-            "-rate",
-            f"threads={THREADS}"
-        ])
-    except subprocess.CalledProcessError:
-        pytest.fail("[FAILED] READ test failed")
-    print("[SUCCESS] READ test completed")
+    print("[SUCCESS] NoSQLBench basic_check completed successfully")


### PR DESCRIPTION
### Summary

This pull request introduces **NoSQLBench** (`v5.17.3`) into the Charmed Cassandra snap.

NoSQLBench was selected as the benchmarking tool because the official `cassandra-stress` utility is deprecated, as noted in the [official Cassandra documentation](https://cassandra.apache.org/doc/latest/cassandra/tooling/cassandra-stress.html).

Version `v5.17.3` was chosen because it is the latest major release that is fully [documented](https://docs.nosqlbench.io/). Newer releases, including `5.21` and `5.17.9`, were found to have issues with workloads, commands, and general stability.

Additionally, the `README.md` has been updated to include instructions on running benchmarks using NoSQLBench.

### Limitations

NoSQLBench `v5.17.3` still includes the `--docker-metrics` flag, which was removed in newer releases. This flag is not compatible with the snap environment and will not function when used in this context.